### PR TITLE
Use 45px like the original image for the icons in category detail page.

### DIFF
--- a/_includes/category/header.html
+++ b/_includes/category/header.html
@@ -6,7 +6,7 @@
             </div>
             <div class="col-md-6 headerelement">
                 <h1>{{include.title}}</h1>
-                <p><img class="categoryicon" width="20px" src="{{ include.iconurl }}"/></p>
+                <p><img class="categoryicon" width="45px" src="{{ include.iconurl }}"/></p>
             </div>
             <div class="col-md-3 headerelement">
                 <a href="index.html"><img src="https://raw.githubusercontent.com/HanaHaus/HanaHaus-ux/master/01_Website/Assets/00_Common%20Assets/Close_Btn-01.png" /></a>


### PR DESCRIPTION
Fixes #35