### PR TITLE
simpler serve process to allow us to not worry about changing config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,12 +41,9 @@ end
 
 desc "Generate site and host with static file server"
 task :serve => [:generate] do
-  root = File.expand_path '_site'
-  server = WEBrick::HTTPServer.new :Port => 8080, :DocumentRoot => root
-  jekyllPid = Process.spawn "jekyll build --watch"
+  jekyllPid = Process.spawn "jekyll serve --baseurl '/' -d '_site' --port 8080"
   trap 'INT' do
     Process.kill(9, jekyllPid) rescue Errno::ESRCH
     server.shutdown
   end
-  server.start
 end


### PR DESCRIPTION
'jekyll serve' also starts a server that watches changes by default, no need for a separate process (y)